### PR TITLE
Add the maroon function to five

### DIFF
--- a/five.js
+++ b/five.js
@@ -106,6 +106,10 @@
     return ['Jackie','Tito','Jermaine','Marlon','Michael'];
   };
 
+  five.maroon = function() {
+    return ['Mickey Madden','Adam Levine','James Valentine','Jesse Carmichael','PJ Morton','Matt Flynn'];
+  };
+
   /**
    * References "I got 5 on it" by Luniz.
    * http://en.wikipedia.org/wiki/I_Got_5_on_It

--- a/test.js
+++ b/test.js
@@ -95,6 +95,8 @@ assert.equal(JSON.stringify(['Jackie','Tito','Jermaine','Marlon','Michael']), JS
 
 assert.equal(JSON.stringify(['Juwan Howard','Ray Jackson','Jimmy King','Jalen Rose','Chris Webber']), JSON.stringify(five.fab()), 'A fab five should be the 1991-1993 Michigan Mens Basketball Team');
 
+assert.equal(JSON.stringify(['Mickey Madden','Adam Levine','James Valentine','Jesse Carmichael','PJ Morton','Matt Flynn']), JSON.stringify(five.maroon()), 'A maroon five should be the members of the popular band Maroon 5.');
+
 assert.equal(five.luniz(), 'I Got 5 on It', 'A Luniz five should be the song title of their most famous hit');
 
 assert.equal(true, five.isFive(five()));


### PR DESCRIPTION
This adds the ability to call `five.maroon()` which returns the names of the members of Maroon 5 as an array. I feel that this really pushes Five into the 21st Century by showing that it can deal with modern bands.
